### PR TITLE
Fix warning in precedence_matrix()

### DIFF
--- a/R/precedence_matrix_absolute.R
+++ b/R/precedence_matrix_absolute.R
@@ -15,6 +15,8 @@
 #'
 precedence_matrix <- function(eventlog, type = c("absolute","relative","relative-antecedent","relative-consequent", "relative-case")) {
 
+  type = match.arg(type)
+	
   antecedent <- consequent <- NULL
 
 	stopifnot("eventlog" %in% class(eventlog))


### PR DESCRIPTION
Thank you for this useful package.

When the `type` argument isn't provided, a warning is given:

```
Warning message:
In if (type == "absolute") { :
  the condition has length > 1 and only the first element will be used
```

This PR fixes the warning by using `match.arg()` to assign `"absolute"` as the default value.  This is standard practice.

```r
type = match.arg(type)
```